### PR TITLE
fix: Remove instance data attribute "family"

### DIFF
--- a/pyblish/api.py
+++ b/pyblish/api.py
@@ -100,7 +100,6 @@ from .lib import (
 )
 
 from .logic import (
-    plugins_by_family,
     plugins_by_host,
     plugins_by_instance,
     plugins_by_targets,
@@ -246,7 +245,6 @@ __all__ = [
     "registered_guis",
     "deregister_gui",
 
-    "plugins_by_family",
     "plugins_by_host",
     "plugins_by_instance",
     "instances_by_plugin",

--- a/pyblish/logic.py
+++ b/pyblish/logic.py
@@ -182,23 +182,8 @@ def plugins_by_families(plugins, families):
     return compatible
 
 
-def plugins_by_family(plugins, family):
-    """Convenience function to :func:`plugins_by_families`
-
-    Arguments:
-        plugins (list): List of plugins
-        family (str): Family with which to compare against
-
-    Returns:
-        List of compatible plugins.
-
-    """
-
-    return plugins_by_families(plugins, [family])
-
-
 def plugins_by_instance(plugins, instance):
-    """Conveinence function for :func:`plugins_by_family`
+    """Convenience function for :func:`plugins_by_families`
 
     Arguments:
         plugins (list): Plug-ins to assess
@@ -209,11 +194,9 @@ def plugins_by_instance(plugins, instance):
 
     """
 
-    family = instance.data.get("family")
     families = instance.data.get("families", [])
 
-    return plugins_by_families(
-        plugins, ([family] if family else []) + families)
+    return plugins_by_families(plugins, families)
 
 
 def plugins_by_host(plugins, host):
@@ -239,7 +222,7 @@ def plugins_by_host(plugins, host):
 
 
 def plugins_by_targets(plugins, targets):
-    """Reutrn compatible plugins `plugins` to targets `targets`
+    """Return compatible plugins `plugins` to targets `targets`
 
     Arguments:
         plugins (list): List of plugins
@@ -299,9 +282,7 @@ def instances_by_plugin(instances, plugin):
         assert algorithm, ("Plug-in did not provide "
                            "valid matching algorithm: %s" % plugin.match)
 
-        family = instance.data.get("family")
-        families = [family] if family else []
-        families += instance.data.get("families", [])
+        families = instance.data.get("families", [])
 
         if algorithm(plugin.families, families):
             compatible.append(instance)

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -826,7 +826,7 @@ class Instance(AbstractEntity):
 
     def __init__(self, name, parent=None, **kwargs):
         super(Instance, self).__init__(name, parent)
-        self._data["family"] = "default"
+        self._data["families"] = []
         self._data["name"] = name
         self._data.update(kwargs)
 


### PR DESCRIPTION
Delete the obsolete "family" instance data attribute and use only "families".

BREAKING CHANGE: No more backward compatibility with plugins and tools using the "family" instance data attribute.